### PR TITLE
Fix funnel shift

### DIFF
--- a/src/RuntimeCommon.cpp
+++ b/src/RuntimeCommon.cpp
@@ -437,7 +437,7 @@ SymExpr _sym_build_funnel_shift_left(SymExpr a, SymExpr b, SymExpr c) {
   SymExpr concat = _sym_concat_helper(a, b);
   SymExpr shift = _sym_build_unsigned_rem(c, _sym_build_integer(bits, bits));
 
-  return _sym_extract_helper(_sym_build_shift_left(concat, shift), 0, bits);
+  return _sym_extract_helper(_sym_build_shift_left(concat, shift), 2 * bits - 1, bits);
 }
 
 SymExpr _sym_build_funnel_shift_right(SymExpr a, SymExpr b, SymExpr c) {
@@ -445,8 +445,8 @@ SymExpr _sym_build_funnel_shift_right(SymExpr a, SymExpr b, SymExpr c) {
   SymExpr concat = _sym_concat_helper(a, b);
   SymExpr shift = _sym_build_unsigned_rem(c, _sym_build_integer(bits, bits));
 
-  return _sym_extract_helper(_sym_build_logical_shift_right(concat, shift), 0,
-                             bits);
+  return _sym_extract_helper(_sym_build_logical_shift_right(concat, shift), bits - 1,
+                             0);
 }
 
 SymExpr _sym_build_abs(SymExpr expr) {


### PR DESCRIPTION
The funnel shift helpers are using `_sym_extract_helper` incorrectly. 

https://github.com/ndrewh/symcc-rt/blob/892f817f38f5abfa083dd0c1caa7ced821566bf5/src/RuntimeCommon.cpp#L440

The first bit index must be >= the second bit index. This caused hangs in _sym_extract_helper.

Also, according to [the LLVM docs](https://llvm.org/docs/LangRef.html#llvm-fshl-intrinsic) llvm.fshl should extract the most-significant bits, while llvm.fshr extracts the least-significant.